### PR TITLE
Set -p in build so dune will run in release mode with a project root

### DIFF
--- a/msgpck-repr.opam
+++ b/msgpck-repr.opam
@@ -14,4 +14,4 @@ depends: [
   "msgpck" {= "1.3"}
   "ocplib-json-typed" {>= "0.6"}
 ]
-build:[ "jbuilder" "build" "-j" jobs "@install" ]
+build:[ "jbuilder" "build" "-p" name "-j" jobs "@install" ]

--- a/msgpck.opam
+++ b/msgpck.opam
@@ -13,4 +13,4 @@ depends: [
   "jbuilder" {build & >= "1.0+beta19.1"}
   "ocplib-endian" {>= "1.0"}
 ]
-build:[ "jbuilder" "build" "-j" jobs "@install" ]
+build:[ "jbuilder" "build" "-p" name "-j" jobs "@install" ]


### PR DESCRIPTION
The lack of this option causes dune operating on jbuilder repositories to traverse out of the repository and try to build artifacts in the wrong place: https://github.com/ocaml/dune/issues/1039

Already submitted to older versions on OPAM: https://github.com/ocaml/opam-repository/pull/12382